### PR TITLE
Laravel 6

### DIFF
--- a/src/Integrations/Laravel/Connection.php
+++ b/src/Integrations/Laravel/Connection.php
@@ -238,7 +238,7 @@ class Connection extends \Illuminate\Database\Connection
      *
      * @return \Tinderbox\ClickhouseBuilder\Integrations\Laravel\Builder
      */
-    public function table($table)
+    public function table($table, $as = NULL)
     {
         return $this->query()->from($table);
     }

--- a/src/Integrations/Laravel/Connection.php
+++ b/src/Integrations/Laravel/Connection.php
@@ -235,6 +235,7 @@ class Connection extends \Illuminate\Database\Connection
      * Begin a fluent query against a database table.
      *
      * @param string $table
+     * @param string $as
      *
      * @return \Tinderbox\ClickhouseBuilder\Integrations\Laravel\Builder
      */

--- a/src/Integrations/Laravel/Connection.php
+++ b/src/Integrations/Laravel/Connection.php
@@ -239,7 +239,7 @@ class Connection extends \Illuminate\Database\Connection
      *
      * @return \Tinderbox\ClickhouseBuilder\Integrations\Laravel\Builder
      */
-    public function table($table, $as = NULL)
+    public function table($table, $as = null)
     {
         return $this->query()->from($table);
     }


### PR DESCRIPTION
Declaration of Tinderbox\ClickhouseBuilder\Integrations\Laravel\Connection::table($table, $as) must be compatible with Illuminate\Database\Connection::table($table, $as = NULL)