### PR TITLE
fix

### DIFF
--- a/src/Integrations/Laravel/Connection.php
+++ b/src/Integrations/Laravel/Connection.php
@@ -244,9 +244,9 @@ class Connection extends \Illuminate\Database\Connection
      *
      * @return \Tinderbox\ClickhouseBuilder\Integrations\Laravel\Builder
      */
-    public function table($table)
+    public function table($table, $alias = null)
     {
-        return $this->query()->from($table);
+        return $this->query()->from($table, $alias);
     }
     
     /**


### PR DESCRIPTION
Declaration of Tinderbox\ClickhouseBuilder\Integrations\Laravel\Connection::table($table) must be compatible with Illuminate\Database\Connection::table($table, $as = NULL)