### PR TITLE
fix table in Integrations\Laravel\Connection for Laravel 6

### DIFF
--- a/src/Integrations/Laravel/Connection.php
+++ b/src/Integrations/Laravel/Connection.php
@@ -240,13 +240,14 @@ class Connection extends \Illuminate\Database\Connection
     /**
      * Begin a fluent query against a database table.
      *
-     * @param string $table
+     * @param \Closure|Builder|string $table
+     * @param string|null $as
      *
      * @return \Tinderbox\ClickhouseBuilder\Integrations\Laravel\Builder
      */
-    public function table($table)
+    public function table($table, $as = null)
     {
-        return $this->query()->from($table);
+        return $this->query()->from($table, $as);
     }
     
     /**


### PR DESCRIPTION
Compile Error: Declaration of Tinderbox\ClickhouseBuilder\Integrations\Laravel\Connection::table($table) must be compatible with Illuminate\Database\Connection::table($table, $as = NULL)
https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Connection.php#L268