### PR TITLE
Update BaseBuilder.php

### DIFF
--- a/src/Query/BaseBuilder.php
+++ b/src/Query/BaseBuilder.php
@@ -1775,7 +1775,7 @@ abstract class BaseBuilder
      */
     public function format(string $format)
     {
-        $this->format = new Format(strtoupper($format));
+        $this->format = new Format($format);
         
         return $this;
     }


### PR DESCRIPTION
using 

        -> format(Format::JSON_COMPACT)

gave the follwing error

UnexpectedValueException
Value 'JSONCOMPACT' is not part of the enum Tinderbox\ClickhouseBuilder\Query\Enums\Format

PR to correct this