### PR TITLE
Add "sum", "round" functions for Column

### DIFF
--- a/src/Query/Column.php
+++ b/src/Query/Column.php
@@ -195,6 +195,38 @@ class Column
     }
 
     /**
+     * Apply sum function to column.
+     *
+     * @param string|Expression|null $columnName
+     *
+     * @return $this
+     */
+    public function sum($columnName = null): self
+    {
+        if ($columnName !== null) {
+            $this->name($columnName);
+        }
+
+        $this->functions[] = ['function' => 'sum'];
+
+        return $this;
+    }
+
+    /**
+     * Apply round function to column.
+     *
+     * @param int $decimals
+     *
+     * @return $this
+     */
+    public function round(int $decimals = 0): self
+    {
+        $this->functions[] = ['function' => 'round', 'params' => $decimals];
+
+        return $this;
+    }
+
+    /**
      * Apply plus function to column.
      *
      * @param $value

--- a/src/Query/Traits/ColumnCompiler.php
+++ b/src/Query/Traits/ColumnCompiler.php
@@ -101,6 +101,31 @@ trait ColumnCompiler
     }
 
     /**
+     * Compiles sum function on column.
+     *
+     * @param $column
+     *
+     * @return string
+     */
+    private function sum($column)
+    {
+        return "sum({$column})";
+    }
+
+    /**
+     * Compiles round function on column.
+     *
+     * @param $column
+     * @param $decimals
+     *
+     * @return string
+     */
+    private function round($column, $decimals)
+    {
+        return "round({$column}, {$decimals})";
+    }
+
+    /**
      * Compiles distinct function on column.
      *
      * @param $column

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -87,6 +87,37 @@ class ColumnTest extends TestCase
         ], $functions);
     }
 
+    public function testSum()
+    {
+        $column = new Column($this->getBuilder());
+        $column->name('column');
+        $column->sum();
+
+        $functions = $column->getFunctions();
+
+        $this->assertEquals([
+            [
+                'function' => 'sum',
+            ],
+        ], $functions);
+    }
+
+    public function testRound()
+    {
+        $column = new Column($this->getBuilder());
+        $column->name('column');
+        $column->round(2);
+
+        $functions = $column->getFunctions();
+
+        $this->assertEquals([
+            [
+                'function' => 'round',
+                'params'   => 2,
+            ],
+        ], $functions);
+    }
+
     public function testPlus()
     {
         $column = new Column($this->getBuilder());

--- a/tests/GrammarTest.php
+++ b/tests/GrammarTest.php
@@ -176,6 +176,27 @@ class GrammarTest extends TestCase
         $this->assertEquals('SELECT sumIf(`column`, > 10)', $select);
 
         $builder->select(function ($column) {
+            $column->name('column')->sum();
+        });
+
+        $select = $grammar->compileSelect($builder);
+        $this->assertEquals('SELECT sum(`column`)', $select);
+
+        $builder->select(function ($column) {
+            $column->sum('column');
+        });
+
+        $select = $grammar->compileSelect($builder);
+        $this->assertEquals('SELECT sum(`column`)', $select);
+
+        $builder->select(function ($column) {
+            $column->sum('column')->round(2);
+        });
+
+        $select = $grammar->compileSelect($builder);
+        $this->assertEquals('SELECT round(sum(`column`), 2)', $select);
+
+        $builder->select(function ($column) {
             $column->name('column')->distinct();
         });
 


### PR DESCRIPTION
Hello! I've decided to add most frequently used functions for Column - sum & round
Here are examples:

```
// SELECT sum(`column`)
$builder->select(function ($column) {
    $column->name('column')->sum();
});
```

```
// SELECT sum(`column`)
$builder->select(function ($column) {
    $column->sum('column');
});
```

```
// SELECT round(sum(`column`), 2)
$builder->select(function ($column) {
    $column->sum('column')->round(2);
});
```

If it's ok I can continue with some other functions.