### PR TITLE
Fixing sleep for mutation.

### DIFF
--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -1059,12 +1059,16 @@ class BuilderTest extends TestCase
 
         $builder->newQuery()->table('test')->insertFile(['number'], new FileFromString('0'.PHP_EOL.'1'.PHP_EOL.'2'));
 
+        $result = $builder->newQuery()->table('test')->count();
+
+        $this->assertEquals(3, $result);
+
+        $builder->newQuery()->table('test')->where('number', '=', 1)->delete();
+
         /*
          * We have to sleep for 3 seconds while mutation in progress
          */
         sleep(3);
-
-        $builder->newQuery()->table('test')->where('number', '=', 1)->delete();
 
         $result = $builder->newQuery()->table('test')->count();
 

--- a/tests/LaravelIntegrationTest.php
+++ b/tests/LaravelIntegrationTest.php
@@ -548,12 +548,16 @@ class LaravelIntegrationTest extends TestCase
             new FileFromString('0'.PHP_EOL.'1'.PHP_EOL.'2'),
         ]);
 
+        $result = $connection->table('test')->select($connection->raw('count() as count'))->get();
+
+        $this->assertEquals(3, $result[0]['count']);
+
+        $connection->table('test')->where('number', '=', 1)->delete();
+
         /*
          * We have to sleep for 3 seconds while mutation in progress
          */
         sleep(3);
-
-        $connection->table('test')->where('number', '=', 1)->delete();
 
         $result = $connection->table('test')->select($connection->raw('count() as count'))->get();
 


### PR DESCRIPTION
When running unit test locally without xdebug extension, I encountered the following failures.
```
1) Tinderbox\ClickhouseBuilder\BuilderTest::testDelete
Failed asserting that '3' matches expected 2.

2) Tinderbox\ClickhouseBuilder\LaravelIntegrationTest::test_builder_delete
Failed asserting that '3' matches expected 2.
```

According to the [document](https://clickhouse.tech/docs/en/sql-reference/statements/alter/#mutations), mutations is mostly for `ALTER` queries especially delete and update, so it is better to put `sleep` after calling `delete`.

Maybe with xdebug, the execution is slow enough, so the mutation has done before getting count result.
