### PR TITLE
Support Join ON expressions

### DIFF
--- a/src/Query/JoinClause.php
+++ b/src/Query/JoinClause.php
@@ -127,19 +127,19 @@ class JoinClause
     /**
      * Set "on" clause for join.
      *
-     * @param string $first
-     * @param string $operator
-     * @param string $second
-     * @param string $concatOperator
+     * @param string|Expression $first
+     * @param string            $operator
+     * @param string|Expression $second
+     * @param string            $concatOperator
      *
      * @return JoinClause
      */
-    public function on(string $first, string $operator, string $second, string $concatOperator = Operator::AND): self
+    public function on($first, string $operator, $second, string $concatOperator = Operator::AND): self
     {
         $expression = (new TwoElementsLogicExpression($this->query))
-            ->firstElement(new Identifier($first))
+            ->firstElement(is_string($first) ? new Identifier($first) : $first)
             ->operator($operator)
-            ->secondElement(new Identifier($second))
+            ->secondElement(is_string($second) ? new Identifier($second) : $second)
             ->concatOperator($concatOperator);
 
         $this->onClauses[] = $expression;

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -1171,6 +1171,12 @@ class BuilderTest extends TestCase
             $join->table('table2')->on('column_from_table_1', '=', 'column_from_table_2');
         });
         $this->assertEquals('SELECT * FROM `table1` ANY LEFT JOIN `table2` ON `column_from_table_1` = `column_from_table_2`', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->from('table1')->anyLeftJoin(function (JoinClause $join) {
+            $join->table('table2')->on('column_from_table_1', '=', raw('toUInt32(`column_from_table_2`)'));
+        });
+        $this->assertEquals('SELECT * FROM `table1` ANY LEFT JOIN `table2` ON `column_from_table_1` = toUInt32(`column_from_table_2`)', $builder->toSql());
     }
 
     public function testMultipleJoins()


### PR DESCRIPTION
It's a common situation when join columns types are mismatching. It causes an error.
In my case I use something like this:

```
JOIN ON column_from_table_1 = toUInt32(column_from_table_2)
```

In my commit I add a support for such expressions in `on()` method.

```
$join->table('table2')->on('column_from_table_1', '=', raw('toUInt32(`column_from_table_2`)'));
```