### PR TITLE
Update PHPUnit configs & paginate() count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 tests/coverage
 composer.lock
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,12 +14,12 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="coverage" charset="UTF-8"/>
-    </logging>
+        </include>
+        <report>
+            <html outputDirectory="tests/coverage"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/src/Integrations/Laravel/Builder.php
+++ b/src/Integrations/Laravel/Builder.php
@@ -197,7 +197,7 @@ class Builder extends BaseBuilder
      */
     public function paginate(int $page = 1, int $perPage = 15): LengthAwarePaginator
     {
-        $count = $this->getConnection()
+        $count = (int) $this->getConnection()
             ->table($this->cloneWithout(['columns' => []])
             ->select(new Expression('1')))
             ->count();


### PR DESCRIPTION
## phpunit.xml

PHPUnit 9.3 deprecated some tags used in the current  `phpunit.xml`, so:

- change `<filter><whitelist><include>...</include></whitelist></filter>` to `<coverage><include>...</include></coverage>`
- change `<logging><log type="coverage-html" target="coverage" charset="UTF-8"/>`
  `</logging>` to `<coverage><report><html outputDirectory="tests/coverage"/></report></coverage>`

### Reference:

- https://github.com/infection/infection/issues/1282
- https://github.com/sebastianbergmann/phpunit/blob/a0d6b21c6c8f6564212a1a14292d230ee35eba6d/ChangeLog-9.3.md#930---2020-08-07

## Working with Laravel - paginate()

- make sure `$count` gets an `int` value so that the returned paginator->`total` will also be `int`