### PR TITLE
Update functions.php

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -10,8 +10,11 @@ if (!function_exists('tap')) {
      *
      * @return mixed
      */
-    function tap($value, $callback)
+    function tap($value, $callback = null)
     {
+        if (is_null($callback)) {
+            return new \Illuminate\Support\HigherOrderTapProxy($value);
+        }
         $callback($value);
 
         return $value;


### PR DESCRIPTION
Error on laravel version 9.34+, When using a package, this function is connected before another one from the Laravel package and vendor falls off

```In functions.php line 13:
                                                                                                                                                                                                 
  Too few arguments to function tap(), 1 passed in /home/domains/sales-plans-service/vendor/laravel/framework/src/Illuminate/Foundation/Console/CliDumper.php on line 71 and exactly 2 expected```